### PR TITLE
Paint events

### DIFF
--- a/include/RudeDrawer.h
+++ b/include/RudeDrawer.h
@@ -13,6 +13,7 @@ typedef enum {
     RDCMD_START_POLLING_EVENTS_WIN,
     RDCMD_STOP_POLLING_EVENTS_WIN,
     RDCMD_GET_DISPLAY_SHM_WIN,
+    RDCMD_SEND_PAINT_EVENT,
 } RudeDrawerCommandKind;
 
 typedef struct {
@@ -54,6 +55,7 @@ typedef struct {
 typedef enum {
     RDEVENT_NONE,
     RDEVENT_CLOSE_WIN,
+    RDEVENT_PAINT,
 } RudeDrawerEventKind;
 
 typedef struct {

--- a/src/AppDrawer/AppDrawer.cpp
+++ b/src/AppDrawer/AppDrawer.cpp
@@ -202,8 +202,6 @@ void AppDrawer::handleClient(int clientFd) noexcept(true)
                 continue;
             }
 
-            if (client.sendErrOrFail(RDERROR_OK) != CLIENT_OK) continue;
-
             if (windows[i]->events.isPolling) {
                 RudeDrawerEvent event;
                 event.kind = RDEVENT_PAINT;

--- a/src/TestClient/Main.cpp
+++ b/src/TestClient/Main.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <iostream>
@@ -223,11 +224,6 @@ void Draw::sendPaintEvent(uint32_t id) noexcept(false)
     command.kind = RDCMD_SEND_PAINT_EVENT;
     command.windowId = id;
     send(&command, sizeof(RudeDrawerCommand));
-
-    RudeDrawerResponse response;
-    recv(&response, sizeof(RudeDrawerResponse));
-
-    NOTOK(response);
 }
 
 Display* Draw::getDisplay(uint32_t id, RudeDrawerVec2D dims) noexcept(false)
@@ -267,7 +263,10 @@ Draw::~Draw() noexcept(true)
 
 void sendPaintEvents(Draw& draw, uint32_t id)
 {
-    draw.sendPaintEvent(id);
+    while (true) {
+        draw.sendPaintEvent(id);
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
 }
 
 int main() noexcept(true)

--- a/src/TestClient/Main.cpp
+++ b/src/TestClient/Main.cpp
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <unistd.h>
 #include <fcntl.h>
+#include <thread>
 
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -74,7 +75,6 @@ private:
 
     void send(void* data, size_t n) noexcept(false);
     void recv(void* data, size_t n) noexcept(false);
-    void notOk(RudeDrawerResponse resp) noexcept(false);
 public:
     void connect() noexcept(false);
     void ping() noexcept(false);
@@ -82,6 +82,7 @@ public:
     void removeWindow(uint32_t id) noexcept(false);
     void startPollingEventsWindow(uint32_t id) noexcept(false);
     void stopPollingEventsWindow(uint32_t id) noexcept(false);
+    void sendPaintEvent(uint32_t id) noexcept(false);
     Display* getDisplay(uint32_t id, RudeDrawerVec2D dims) noexcept(false);
     RudeDrawerEvent pollEvent() noexcept(false);
 
@@ -110,14 +111,13 @@ void Draw::recv(void* data, size_t n) noexcept(false)
     }
 }
 
-void Draw::notOk(RudeDrawerResponse resp) noexcept(false)
-{
-    if (resp.errorKind != RDERROR_OK) {
-        std::ostringstream error;
-        error << "ERROR: Not OK: Code " << resp.errorKind;
-        throw std::runtime_error(error.str());
-    }
-}
+#define NOTOK(resp)                                     \
+    if ((resp).errorKind != RDERROR_OK) {               \
+        std::ostringstream error;                       \
+        error << "ERROR: " << __FUNCTION__              \
+              << ": Not OK: Code " << (resp).errorKind; \
+        throw std::runtime_error(error.str());          \
+    }                                                   \
 
 void Draw::connect() noexcept(false)
 {
@@ -154,7 +154,7 @@ void Draw::ping() noexcept(false)
     RudeDrawerResponse response;
     recv(&response, sizeof(RudeDrawerResponse));
 
-    notOk(response);
+    NOTOK(response);
 }
 
 uint32_t Draw::addWindow(std::string title, RudeDrawerVec2D dims) noexcept(false)
@@ -169,7 +169,7 @@ uint32_t Draw::addWindow(std::string title, RudeDrawerVec2D dims) noexcept(false
     RudeDrawerResponse response;
     recv(&response, sizeof(RudeDrawerResponse));
 
-    notOk(response);
+    NOTOK(response);
 
     if (response.kind != RDRESP_WINID) {
         throw std::runtime_error("ERROR: response is not of kind `RDRESP_WINID`");
@@ -188,7 +188,7 @@ void Draw::removeWindow(uint32_t id) noexcept(false)
     RudeDrawerResponse response;
     recv(&response, sizeof(RudeDrawerResponse));
 
-    notOk(response);
+    NOTOK(response);
 }
 
 void Draw::startPollingEventsWindow(uint32_t id) noexcept(false)
@@ -201,7 +201,7 @@ void Draw::startPollingEventsWindow(uint32_t id) noexcept(false)
     RudeDrawerResponse response;
     recv(&response, sizeof(RudeDrawerResponse));
 
-    notOk(response);
+    NOTOK(response);
 }
 
 void Draw::stopPollingEventsWindow(uint32_t id) noexcept(false)
@@ -214,7 +214,20 @@ void Draw::stopPollingEventsWindow(uint32_t id) noexcept(false)
     RudeDrawerResponse response;
     recv(&response, sizeof(RudeDrawerResponse));
 
-    notOk(response);
+    NOTOK(response);
+}
+
+void Draw::sendPaintEvent(uint32_t id) noexcept(false)
+{
+    RudeDrawerCommand command;
+    command.kind = RDCMD_SEND_PAINT_EVENT;
+    command.windowId = id;
+    send(&command, sizeof(RudeDrawerCommand));
+
+    RudeDrawerResponse response;
+    recv(&response, sizeof(RudeDrawerResponse));
+
+    NOTOK(response);
 }
 
 Display* Draw::getDisplay(uint32_t id, RudeDrawerVec2D dims) noexcept(false)
@@ -227,7 +240,7 @@ Display* Draw::getDisplay(uint32_t id, RudeDrawerVec2D dims) noexcept(false)
     RudeDrawerResponse response;
     recv(&response, sizeof(RudeDrawerResponse));
 
-    notOk(response);
+    NOTOK(response);
 
     if (response.kind != RDRESP_SHM_NAME) {
         throw std::runtime_error("ERROR: response is not of kind `RDRESP_SHM_NAME`");
@@ -250,6 +263,11 @@ Draw::~Draw() noexcept(true)
 {
     std::cout << "[INFO] Closing connection\n";
     close(socket);
+}
+
+void sendPaintEvents(Draw& draw, uint32_t id)
+{
+    draw.sendPaintEvent(id);
 }
 
 int main() noexcept(true)
@@ -275,12 +293,19 @@ int main() noexcept(true)
     TRY(display->destroy());
 
     TRY(draw.startPollingEventsWindow(id));
+
+    std::thread thread(&sendPaintEvents, std::ref(draw), id);
+    thread.detach();
+
     bool quit = false;
     while (!quit) {
         auto event = draw.pollEvent();
         switch (event.kind) {
         case RDEVENT_NONE:
             std::cout << "WTF None event!!??\n";
+            break;
+        case RDEVENT_PAINT:
+            std::cout << "Paint event!!\n";
             break;
         case RDEVENT_CLOSE_WIN:
             std::cout << "Received close window event\n";


### PR DESCRIPTION
This introduces a new kind of event, the `RDEVENT_PAINT`, and also introduces a command to request for a paint event, that being `RDCMD_SEND_PAINT_EVENT`. This gives the client control to receive paint events only when needed (useful when implementing a timer that would update some sort of UI once every N seconds, for example).